### PR TITLE
fix: remove MCR_API from template instantiations

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -455,8 +455,10 @@ The thread-local `mcr_err` variable and all related infrastructure were removed 
 - Investigate dispatching an `mcr_Signal` copy as a message to the dispatch thread.
 - Evaluate a message queue as an alternative to thread-local events.
 
-### ABI & Export Audit
-- Audit exported types/classes for templates that cannot be exported; identify candidates for header-only implementation without `MCR_API`.
+### ~~ABI & Export Audit~~ (FIXED 2026-07-23)
+- ~~Audit exported types/classes for templates that cannot be exported; identify candidates for header-only implementation without `MCR_API`.~~
+
+**Resolution:** Removed 5 `template struct MCR_API` explicit instantiations from `mcr/template/list.h`, `mcr/signal.h`, and `mcr/trigger.h`. The `List<T>` template was already fully header-only (all methods inline in the header). The explicit instantiations with `MCR_API` were ABI-hazardous — `__declspec(dllexport)` / `visibility("default")` on template specializations forces consumers to match the exact compiler, STL, and flags. The codebase already followed the correct pattern for header-only templates (`FunctorSignal`, `FunctorActor`, `FunctorTrigger`, `TSignalAllocator<T>`, `TTriggerAllocator<T>`). Typedefs (`CStringList`, `IntList`, `UIntList`, `SignalList`, `TriggerList`) unchanged. Build succeeds, all 80 tests pass.
 
 ### Safety & Correctness Review
 - Perform a memory safety audit (UAF, double-free, buffer overflows, null dereferences, etc.).

--- a/mcr/signal.h
+++ b/mcr/signal.h
@@ -49,7 +49,6 @@ class MCR_API Signal {
 	virtual void send() = 0;
 };
 
-template struct MCR_API List<Signal>;
 /**
  * @brief A list of Signal pointers that can be sent as a group.
  */

--- a/mcr/template/list.h
+++ b/mcr/template/list.h
@@ -115,9 +115,6 @@ template <typename ElementT> struct List {
 		return !count;
 	}
 };
-template struct MCR_API List<const char *>;
-template struct MCR_API List<int>;
-template struct MCR_API List<unsigned int>;
 /** @brief List of C strings. */
 typedef List<const char *> CStringList;
 /** @brief List of integers. */

--- a/mcr/trigger.h
+++ b/mcr/trigger.h
@@ -83,7 +83,6 @@ class MCR_API Trigger : public IReceive {
 	}
 };
 
-template struct MCR_API List<Trigger>;
 /**
  * @brief A list of Triggers that also acts as an IReceive.
  *


### PR DESCRIPTION
Reviewed ABI and export. Be aware there may be other classes that could be header-only.
Remove 5 template struct MCR_API explicit instantiations that attempted to export template specializations from the shared library. List<T> was already fully header-only; the explicit instantiations were ABI-hazardous (consumers must match exact compiler/STL/flags). Typedefs and all non-template exports unchanged. All 80 tests pass.

Fixes: #24 